### PR TITLE
correcting misplaced registrationPage field.

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -33,7 +33,8 @@
   "types": [
     {
       "information": {
-        "value": "MRI"
+        "value": "MRI",
+		"valueIRI": "http://uri.interlex.org/ilx_0779748"
       }
     },
     {

--- a/DATS.json
+++ b/DATS.json
@@ -164,6 +164,14 @@
         }
       ]
     },
+	{
+      	"category": "registrationPage",
+      	"values": [
+       		{
+       			"value": "https://www.braincode.ca/user/register"
+        	}
+      	]
+    },
     {
       "category": "origin_institution",
       "values": [
@@ -2777,14 +2785,6 @@
             }
           ]
         },
-		{
-      		"category": "registrationPage",
-      		"values": [
-        		{
-          			"value": "https://www.braincode.ca/user/register"
-        		}
-      		]
-    	},
         {
           "category": "origin_institution",
           "values": [


### PR DESCRIPTION
This PR corrects an error in placing the updated `registrationPage` field in the wrong `extraProperties` section within the DATS.json file.